### PR TITLE
fix: move installation of kpms from optional to required dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.3.1] - 2025-06-27
+
++ Fix - `setup.py` to install `keypoint-moseq` as a required dependency
 
 ## [0.3.0] - 2025-06-07
 

--- a/element_moseq/version.py
+++ b/element_moseq/version.py
@@ -2,4 +2,4 @@
 Package metadata
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,9 @@ setup(
         "opencv-python",
         "graphviz",
         "pydot",
+        "keypoint-moseq==0.4.8",
     ],
     extras_require={
-        "kpms": [
-            "keypoint-moseq",
-        ],
         "elements": [
             "element-lab @ git+https://github.com/datajoint/element-lab.git",
             "element-session @ git+https://github.com/datajoint/element-session.git",


### PR DESCRIPTION
- [x] Fixed `setup.py` to install `keypoint-moseq` as a required dependency