### PR TITLE
refactor: move `element-deeplabcut` as optional dependency to avoid circular dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [1.0.2] - 2025-10-07
++ Update - Move `element-deeplabcut` as optional dependency to avoid circular dependencies
+
 ## [1.0.1] - 2025-09-23
 + Feat - Add support to generate PNG version of fitting progress plots in `PreFit`, `FullFit`, and `moseq_report` schema
 + Fix - Update path handling to use `Path` objects and `dj.logger`

--- a/element_moseq/version.py
+++ b/element_moseq/version.py
@@ -2,4 +2,4 @@
 Package metadata
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,22 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+
+deeplabcut = [
+    "element-deeplabcut @ git+https://github.com/datajoint/element-deeplabcut.git",
+]
+
 elements = [
     "element-lab @ git+https://github.com/datajoint/element-lab.git",
     "element-session @ git+https://github.com/datajoint/element-session.git",
     "element-interface @ git+https://github.com/datajoint/element-interface.git",
     "element-animal @ git+https://github.com/datajoint/element-animal.git",
 ]
+
+all = [
+    "element-moseq[moseq,deeplabcut,elements]",
+]
+
 tests = [
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,14 +41,14 @@ elements = [
     "element-animal @ git+https://github.com/datajoint/element-animal.git",
 ]
 
-all = [
-    "element-moseq[moseq,deeplabcut,elements]",
-]
-
 tests = [
     "pytest",
     "pytest-cov",
     "shutils",
+]
+
+all = [
+    "element-moseq[deeplabcut,elements,tests]",
 ]
 
 [project.urls]


### PR DESCRIPTION
This pull request updates the package to version 1.0.2 and reorganizes dependencies to avoid circular imports. The main change is moving `element-deeplabcut` to an optional dependency, which improves installation flexibility and resolves potential dependency issues.

Dependency management improvements:

* Moved `element-deeplabcut` to `[project.optional-dependencies]` in `pyproject.toml`, making it an optional dependency and preventing circular dependencies.
* Added new optional dependency groups: `deeplabcut`, `elements`, and `all` in `pyproject.toml` for more flexible installation options.

Version update:

* Bumped package version to `1.0.2` in `element_moseq/version.py`.
* Added a changelog entry for version 1.0.2, documenting the dependency update.